### PR TITLE
Add BeautifulSoup as a required library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(name='musicnow',
           'colorama',
           'argparse',
           'configparser',
+          'BeautifulSoup',
         ],
       entry_points={
         'console_scripts': ['musicnow=musicnow.command_line:main'],


### PR DESCRIPTION
When first using the `musicnow` command line in bash on OS X after installing through `pip install musicnow` I received the following error:

```
Traceback (most recent call last):
  File "/usr/local/bin/musicnow", line 7, in <module>
    from musicnow.command_line import main
  File "/usr/local/lib/python2.7/site-packages/musicnow/command_line.py", line 23, in <module>
    import BeautifulSoup
ImportError: No module named BeautifulSoup
```